### PR TITLE
fix bolt package name mismatch

### DIFF
--- a/plugin/persistence/bbolt/provider.go
+++ b/plugin/persistence/bbolt/provider.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/VolantMQ/vlapi/plugin"
 	"github.com/VolantMQ/vlapi/plugin/persistence"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 var (

--- a/plugin/persistence/bbolt/retained.go
+++ b/plugin/persistence/bbolt/retained.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/VolantMQ/vlapi/plugin/persistence"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 type retained struct {

--- a/plugin/persistence/bbolt/sessions.go
+++ b/plugin/persistence/bbolt/sessions.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/VolantMQ/vlapi/plugin/persistence"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 type sessions struct {

--- a/plugin/persistence/bbolt/system.go
+++ b/plugin/persistence/bbolt/system.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/VolantMQ/vlapi/plugin/persistence"
-	"github.com/coreos/bbolt"
+	bolt "github.com/coreos/bbolt"
 )
 
 type system struct {


### PR DESCRIPTION
I met build errors when I tried to build bbolt plugin.

./provider.go:12:2:_ imported and not used: "github.com/coreos/bbolt"
./provider.go:35:8: undefined: bolt
./retained.go:7:2: imported and not used: "github.com/coreos/bbolt"
./sessions.go:9:2: imported and not used: "github.com/coreos/bbolt"
./system.go:7:2: imported and not used: "github.com/coreos/bbolt"