### PR TITLE
Added instructions to readme to specify correct module name since use…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,9 @@
 - in-memory
 - bbolt
 
+### Local development and testing
+#### Instructions to pull go module 
+
+```go get github.com/VolantMQ/vlapi```
+
 ## TBD


### PR DESCRIPTION
From v0.1.0 onwards, we noticed that few users were trying to pull this project using an incorrect module name i.e. github.com/volantmq/vlapi instead of github.com/VolantMQ/vlapi. 

This failure is reflected in https://search.gocenter.io/github.com~2Fvolantmq~2Fvlapi/info?version=v0.1.0 whereas the correct one is https://search.gocenter.io/github.com~2FVolantMQ~2Fvlapi/info?version=v0.1.0

